### PR TITLE
Added note about 3DSecure setting

### DIFF
--- a/docs/3.4.0/payment-providers/sage-pay/README.md
+++ b/docs/3.4.0/payment-providers/sage-pay/README.md
@@ -61,6 +61,10 @@ Sage Pay support a wide range of different settings which you can read more abou
 		<td>testMode</td>
 		<td>Whether or not demo mode is enabled</td>
 	</tr>
+	<tr>
+		<td>Apply3DSecure</td>
+		<td>This should be added and set to 0 to ensure 3D Secure is used when possible</td>
+	</tr>
 </table>
 
 ![sage-pay-4.png](/img/ba2a375-sage-pay-4.png)


### PR DESCRIPTION
It won't be necessary to set this once an existing pull request is merged, however it will still be useful for anyone using the current version as of 23/09/20

SagePay itself has a default value of 0, however the existing code sets this to 2 which disables 3D Secure and leaves the site unprotected from chargebacks from fraudulent card use.